### PR TITLE
making header clickable

### DIFF
--- a/src/js/addons/jquery.mmenu.header.js
+++ b/src/js/addons/jquery.mmenu.header.js
@@ -53,6 +53,7 @@
 									$nxt = $panl.find('.' + that.conf.classNames[ _ADDON_ ].panelNext);
 	
 								var _ttl = $ttl.html(),
+									_link = '',
 									_prv = $prv.attr( 'href' ),
 									_nxt = $nxt.attr( 'href' );
 									
@@ -62,6 +63,7 @@
 								if ( !_ttl )
 								{
 									_ttl = $panl.find('.' + _c.subclose).html();
+									_link = $('#menu .mm-subopen[href="#' + $panl[0].id + '"]').next('a').attr('href') || '/';
 								}
 								if ( !_ttl )
 								{
@@ -76,7 +78,11 @@
 								var updateHeader = function()
 								{
 									$titl[ _ttl ? 'show' : 'hide' ]();
-									$titl.html( _ttl );
+									if (_link) {
+										$titl.html('<a href="' + _link + '">' + _ttl + '</a>');
+									} else {
+										$titl.html( _ttl );
+									}
 	
 									$prev[ _prv ? 'attr' : 'removeAttr' ]( 'href', _prv );
 									$prev[ _prv || _prv_txt ? 'show' : 'hide' ]();


### PR DESCRIPTION
Grabbing the href associated with the current header and using it to make the header a clickable link (when using the header add-on). 
User feedback prompted me to do this for BotchTheCrab.com, which uses mmenu. 
Unfortunately, in addition to being a GitHub newbie, I am utterly unfamiliar with everything that goes into using Guard to create a minified version, otherwise I would have provided that as well.