### PR TITLE
Fix npm install 'No repository field' warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
 	"name"			: "jQuery.mmenu",
 	"version"		: "5.2.0",
 	"author"		: "Fred Heusschen <info@frebsite.nl>",
+	"repository"    : {
+    	"type": "git",
+    	"url" : "https://github.com/BeSite/jQuery.mmenu.git"
+  	},
 	"description"	: "The best jQuery plugin for app look-alike on- and off-canvas menus with sliding submenus for your website and webapp.",
 	"keywords"		: [
 		"app",


### PR DESCRIPTION
Fix warning during npm install:

```
npm WARN package.json jQuery.mmenu@5.2.0 No repository field.
```