### PR TITLE
change package name to respect npm naming conventions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name"			: "jQuery.mmenu",
+	"name"			: "jquery.mmenu",
 	"version"		: "5.3.1",
 	"author"		: "Fred Heusschen <info@frebsite.nl>",
 	"repository"    : {


### PR DESCRIPTION
NPM does not allow uppercase letters in package names, so I changed it to all lowercase in order to be able to publish it there.