### PR TITLE
Fix for Bug #387 and Swipe close addon

### DIFF
--- a/src/js/addons/jquery.mmenu.swipeclose.js
+++ b/src/js/addons/jquery.mmenu.swipeclose.js
@@ -1,0 +1,124 @@
+/*	
+ * jQuery mmenu swipeClose addon
+ * mmenu.frebsite.nl
+ *
+ * Copyright (c) Fred Heusschen
+ */
+
+(function( $ ) {
+
+	var _PLUGIN_ = 'mmenu',
+		_ADDON_  = 'swipeClose';
+
+
+	$[ _PLUGIN_ ].addons[ _ADDON_ ] = {
+
+		//	setup: fired once per menu
+		setup: function()
+		{
+			var that = this,
+				opts = this.opts[ _ADDON_ ],
+				conf = this.conf[ _ADDON_ ];
+
+			glbl = $[ _PLUGIN_ ].glbl;
+
+			//	Extend shortcut options
+			if ( typeof opts == 'boolean' )
+			{
+				opts = {
+					close: opts
+				};
+			}
+			if ( typeof opts != 'object' )
+			{
+				opts = {};
+			}
+			opts = this.opts[ _ADDON_ ] = $.extend( true, {}, $[ _PLUGIN_ ].defaults[ _ADDON_ ], opts );
+
+
+			//	Swipe close
+			if ( opts.close )
+			{
+
+				//	Set up variables
+				var closeGesture, prevGesture;
+
+				switch( this.opts.offCanvas.position )
+				{
+					case 'left':
+						closeGesture 	= 'swipeleft';
+						prevGesture		= 'swiperight';
+						break;
+	
+					case 'right':
+						closeGesture 	= 'swiperight';
+						prevGesture		= 'swiperight';
+						break;
+	
+					case 'top':
+						closeGesture 	= 'swipeup';
+						prevGesture		= 'swiperight';
+						break;
+	
+					case 'bottom':
+						closeGesture 	= 'swipedown';
+						prevGesture		= 'swiperight';
+						break;
+				}
+
+				//	Bind events
+				var _hammer = new Hammer( this.$menu[0], opts.vendors.hammer );
+				_hammer
+					.on( closeGesture,
+						function( e )
+						{
+							if ( that.opts.offCanvas ) {
+								var prev = that.$menu.find('.' + _c.prev + ':visible');
+								if (prev.length == 0) that.close();
+								else if (closeGesture != prevGesture) that.close();
+							}
+						}
+					)
+					.on( prevGesture,
+						function( e )
+						{
+							var prev = that.$menu.find('.' + _c.prev + ':visible');
+							if (prev.length > 0) prev.click();
+						}
+					);
+			}
+		},
+
+		//	add: fired once per page load
+		add: function()
+		{
+			if ( typeof Hammer != 'function' || Hammer.VERSION < 2 )
+			{
+				$[ _PLUGIN_ ].addons[ _ADDON_ ].setup = function() {};
+				return;
+			}
+
+			_c = $[ _PLUGIN_ ]._c;
+			_d = $[ _PLUGIN_ ]._d;
+			_e = $[ _PLUGIN_ ]._e;
+		},
+
+		//	clickAnchor: prevents default behavior when clicking an anchor
+		clickAnchor: function( $a, inMenu ) {}
+	};
+
+
+	//	Default options and configuration
+	$[ _PLUGIN_ ].defaults[ _ADDON_ ] = {
+		close		: false,
+		vendors		: {
+			hammer		: {}
+		}
+	};
+	$[ _PLUGIN_ ].configuration[ _ADDON_ ] = {
+	};
+
+
+	var _c, _d, _e, glbl;
+
+})( jQuery );

--- a/src/scss/addons/jquery.mmenu.iconpanels.scss
+++ b/src/scss/addons/jquery.mmenu.iconpanels.scss
@@ -20,6 +20,7 @@
 	{
 		left: -$mm_iconpanelWidth;
 		right: $mm_iconpanelWidth;
+		overflow-y: hidden;
 
 		@include mm_webkit_prefix( 'transform', translate3d( 0, 0, 0 ) );
 	}
@@ -48,7 +49,7 @@
 	position: absolute;
 	top: 0;
 	right: 0;
-	bottom: 0;
+	bottom: -10000px;
 	left: 0;
 	z-index: 3;
 }


### PR DESCRIPTION
Fix for Bug #387. Tested with the following browsers:
- Chrome 43 (Win7)
- Firefox 39 (Win7)
- Safari 5.1.7 (Win7)
- Mobile Safari (iOS8.4)
- Chrome 43 (Android 5.0)

Description for new Swipe close addon:
To enable the menu/submenu to be closed by a swiping gesture, include the Hammer library, the "swipeClose" add-on .js file and use the swipeClose options.