### PR TITLE
Additional addon and extensions for icon panels addon

### DIFF
--- a/src/js/addons/jquery.mmenu.swipeclose.js
+++ b/src/js/addons/jquery.mmenu.swipeclose.js
@@ -1,0 +1,127 @@
+/*	
+ * jQuery mmenu swipeClose addon
+ * mmenu.frebsite.nl
+ *
+ * Copyright (c) Fred Heusschen
+ */
+
+(function( $ ) {
+
+	var _PLUGIN_ = 'mmenu',
+		_ADDON_  = 'swipeClose';
+
+
+	$[ _PLUGIN_ ].addons[ _ADDON_ ] = {
+
+		//	setup: fired once per menu
+		setup: function()
+		{
+			var that = this,
+				opts = this.opts[ _ADDON_ ],
+				conf = this.conf[ _ADDON_ ];
+
+			glbl = $[ _PLUGIN_ ].glbl;
+
+			//	Extend shortcut options
+			if ( typeof opts == 'boolean' )
+			{
+				opts = {
+					close: opts
+				};
+			}
+			if ( typeof opts != 'object' )
+			{
+				opts = {};
+			}
+			opts = this.opts[ _ADDON_ ] = $.extend( true, {}, $[ _PLUGIN_ ].defaults[ _ADDON_ ], opts );
+
+
+			//	Swipe close
+			if ( opts.close )
+			{
+
+				//	Set up variables
+				var closeGesture, prevGesture;
+
+				switch( this.opts.offCanvas.position )
+				{
+					case 'left':
+						closeGesture = 'swipeleft';
+						break;
+	
+					case 'right':
+						closeGesture = 'swiperight';
+						break;
+	
+					case 'top':
+						closeGesture = 'swipeup';
+						break;
+	
+					case 'bottom':
+						closeGesture = 'swipedown';
+						break;
+				}
+
+				if ( this.opts.extensions.indexOf( 'mm-leftsubpanel' ) != -1 )
+				{
+					prevGesture = 'swipeleft';
+				} else {
+					prevGesture = 'swiperight';
+				}
+
+				//	Bind events
+				var _hammer = new Hammer( this.$menu[0], opts.vendors.hammer );
+				_hammer
+					.on( closeGesture,
+						function( e )
+						{
+							if ( that.opts.offCanvas ) {
+								var prev = that.$menu.find('.' + _c.prev + ':visible');
+								if (prev.length == 0) that.close();
+								else if (closeGesture != prevGesture) that.close();
+							}
+						}
+					)
+					.on( prevGesture,
+						function( e )
+						{
+							var prev = that.$menu.find('.' + _c.prev + ':visible');
+							if (prev.length > 0) prev.click();
+						}
+					);
+			}
+		},
+
+		//	add: fired once per page load
+		add: function()
+		{
+			if ( typeof Hammer != 'function' || Hammer.VERSION < 2 )
+			{
+				$[ _PLUGIN_ ].addons[ _ADDON_ ].setup = function() {};
+				return;
+			}
+
+			_c = $[ _PLUGIN_ ]._c;
+			_d = $[ _PLUGIN_ ]._d;
+			_e = $[ _PLUGIN_ ]._e;
+		},
+
+		//	clickAnchor: prevents default behavior when clicking an anchor
+		clickAnchor: function( $a, inMenu ) {}
+	};
+
+
+	//	Default options and configuration
+	$[ _PLUGIN_ ].defaults[ _ADDON_ ] = {
+		close		: false,
+		vendors		: {
+			hammer		: {}
+		}
+	};
+	$[ _PLUGIN_ ].configuration[ _ADDON_ ] = {
+	};
+
+
+	var _c, _d, _e, glbl;
+
+})( jQuery );

--- a/src/scss/extensions/jquery.mmenu.leftsubpanel.scss
+++ b/src/scss/extensions/jquery.mmenu.leftsubpanel.scss
@@ -1,0 +1,30 @@
+/*
+	jQuery.mmenu leftsubpanel extension CSS
+*/
+
+@import "../_inc/variables";
+
+@mixin mm_left_iconpanel_positioning( $nr )
+{
+	.mm-iconpanel.mm-leftsubpanel .mm-panel.mm-iconpanel-#{$nr}
+	{
+		left: 0px;
+		right: $mm_iconpanelWidth * $nr;
+	}
+}
+
+.mm-menu.mm-leftsubpanel
+{
+	.mm-panel:not(.mm-opened)
+	{
+		@include mm_webkit_prefix( 'transform', translate3d( -100%, 0, 0 ) );
+	}
+}
+
+@include mm_left_iconpanel_positioning( 0 );
+@include mm_left_iconpanel_positioning( 1 );
+@include mm_left_iconpanel_positioning( 2 );
+@include mm_left_iconpanel_positioning( 3 );
+@include mm_left_iconpanel_positioning( 4 );
+@include mm_left_iconpanel_positioning( 5 );
+@include mm_left_iconpanel_positioning( 6 );

--- a/src/scss/extensions/jquery.mmenu.panelshadow.scss
+++ b/src/scss/extensions/jquery.mmenu.panelshadow.scss
@@ -1,0 +1,21 @@
+/*
+	jQuery.mmenu panelshadow extension CSS
+*/
+
+@import "../_inc/variables";
+
+@mixin mm_iconpanel_shadow( $nr )
+{
+	.mm-iconpanel.mm-panelshadow .mm-panel.mm-iconpanel-#{$nr}
+	{
+		box-shadow: $mm_pageShadow;
+	}
+}
+
+@include mm_iconpanel_shadow( 0 );
+@include mm_iconpanel_shadow( 1 );
+@include mm_iconpanel_shadow( 2 );
+@include mm_iconpanel_shadow( 3 );
+@include mm_iconpanel_shadow( 4 );
+@include mm_iconpanel_shadow( 5 );
+@include mm_iconpanel_shadow( 6 );


### PR DESCRIPTION
This pull request contains one addon and two extensions to extend icon panels functionality. There is one file for each addon/extension. They can be used all at once or individually.

Swipe close addon:
To enable the menu/submenu to be closed by a swiping gesture, include the Hammer library, the "swipeClose" add-on .js file and use the swipeClose options. (Works with/without icon panels addon.)

Left subpanel extension:
If you want the subpanel to appear from the left, include the "leftSubpanel" extension .css file and add "leftsubpanel" to the extensions option. (Use this extension with icon panels addon.)
* This extension is best used in the following combination: left side mmenu + icon panels + swipe close + left subpanel. All your menu/submenus open from left. Swiping left closes submenus/menu. Especially useful when you have multi-level submenus.

Panel shadow extension:
If you want the subpanel to have a shadow to emphasize it's in front of the parent panel, include the "panelShadow" extension .css file and add "panelshadow" to the extensions option. (Use this extension with icon panels addon.)

I hope this pull request will add more value to this wonderful library.