### PR TITLE
Fix for iPhone setSelected issue

### DIFF
--- a/src/js/jquery.mmenu.oncanvas.js
+++ b/src/js/jquery.mmenu.oncanvas.js
@@ -598,7 +598,8 @@
 							{
 
 								//	Set selected item
-								if ( that.__valueOrFn( that.opts.onClick.setSelected, $t ) )
+								var setSelected = that.__valueOrFn( that.opts.onClick.setSelected, $t );
+								if ( setSelected )
 								{
 									that.setSelected( $(e.target).parent() );
 								}
@@ -620,6 +621,12 @@
 								if ( that.__valueOrFn( that.opts.onClick.close, $t, preventDefault ) )
 								{
 									that.close();
+								}
+
+								// Allow browser to redraw before following link.
+								if ( setSelected && !preventDefault ) {
+									e.preventDefault();
+									setTimeout(function(){ window.location = _h; }, 0);
 								}
 							}
 						}


### PR DESCRIPTION
onClick.setSelected does not work for iPhone. Mobile Safari seems to
skip redraw when following link. A simple use of setTimeout fixes the
issue.