### PR TITLE
Bug fix for 3rd party panelshadow extension

### DIFF
--- a/src/3rdparty/extensions/css/jquery.mmenu.panelshadow.scss
+++ b/src/3rdparty/extensions/css/jquery.mmenu.panelshadow.scss
@@ -4,8 +4,8 @@
 
 @import "../../../core/css/_inc/variables";
 
-.mm-menu.mm-panelshadow .mm-panel.mm-opened,
-.mm-menu .mm-panelshadow.mm-panel.mm-opened
+.mm-menu.mm-panelshadow .mm-panel.mm-opened:nth-child(n+2),
+.mm-menu .mm-panelshadow.mm-panel.mm-opened:nth-child(n+2)
 {
 	box-shadow: $mm_panelShadow;
 }


### PR DESCRIPTION
Some android browser (4.2.2 for sure) have a layout issue with box-shadow and overflow-y:auto.
It is not possible to completely workaround the bug, but this fix minimizes it.
Possibly related bug: https://code.google.com/p/android/issues/detail?id=33028